### PR TITLE
Fix import and Axes3D' object is not iterable

### DIFF
--- a/doc/guide/guide-bloch.rst
+++ b/doc/guide/guide-bloch.rst
@@ -396,7 +396,7 @@ Generating Images for Animation
 An example of generating images for generating an animation outside of Python is given below::
 
      import numpy as np
-     b = Bloch()
+     b = qutip.Bloch()
      b.vector_color = ['r']
      b.view = [-40, 30]
      for i in range(len(sx)):
@@ -440,7 +440,7 @@ The code to directly generate an mp4 movie of the Qubit decay is as follows ::
       return ax
 
    ani = animation.FuncAnimation(fig, animate, np.arange(len(sx)),
-                                 init_func=init, blit=True, repeat=False)
+                                 init_func=init, blit=False, repeat=False)
    ani.save('bloch_sphere.mp4', fps=20)
 
 The resulting movie may be viewed here: `bloch_decay.mp4 <https://raw.githubusercontent.com/qutip/qutip/master/doc/figures/bloch_decay.mp4>`_


### PR DESCRIPTION
**Description**
Fixes the import error and TypeError: 'Axes3D' object is not iterable

**Related issues or PRs**
#799

**Changelog**
Fixed import and runtime errors in [http://qutip.org/docs/latest/guide/guide-bloch.html#generating-images-for-animation]( http://qutip.org/docs/latest/guide/guide-bloch.html#generating-images-for-animation)
